### PR TITLE
Release membrane_rtp_h264_plugin v0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The package can be installed by adding `membrane_rtp_h264_plugin` to your list o
 ```elixir
 def deps do
   [
-    {:membrane_rtp_h264_plugin, "~> 0.6.0"}
+    {:membrane_rtp_h264_plugin, "~> 0.7.0"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.RTP.H264.MixProject do
   use Mix.Project
 
-  @version "0.6.0"
+  @version "0.7.0"
   @github_url "https://github.com/membraneframework/membrane_rtp_h264_plugin"
 
   def project do


### PR DESCRIPTION
### Release "Poorly Causal Horse"

| Project | New Version |
|---|---|
| membrane_rtp_h264_plugin | `0.7.0` |


<sup>proudly automated with <a href="https://github.com/membraneframework/sebex">Sebex</a></sup>