### PR TITLE
Handle empty RTP Packets

### DIFF
--- a/lib/rtp_h264/depayloader.ex
+++ b/lib/rtp_h264/depayloader.ex
@@ -41,6 +41,12 @@ defmodule Membrane.RTP.H264.Depayloader do
   end
 
   @impl true
+  def handle_process(:input, %Buffer{payload: ""}, _ctx, state) do
+    Membrane.Logger.debug("Received empty RTP packet. Ignoring")
+    {:ok, state}
+  end
+
+  @impl true
   def handle_process(:input, buffer, _ctx, state) do
     with {:ok, {header, _payload} = nal} <- NAL.Header.parse_unit_header(buffer.payload),
          unit_type = NAL.Header.decode_type(header),


### PR DESCRIPTION
This Pull Request is intended to resolve numerous warnings from H264 Depayloader about malformed packages. It turns out these warnings were being caused by arrival of empty RTP packets, that didn't match the pattern but not because they were malformed as they are expected to arrive.

The fix for this is simple: catch empty packets in additional `handle_process/4` function clause and ignore them
