### PR TITLE
Make sure the proper metadata are used when stap_a RTP packet sets its marker bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The package can be installed by adding `membrane_rtp_h264_plugin` to your list o
 ```elixir
 def deps do
   [
-    {:membrane_rtp_h264_plugin, "~> 0.19.1"}
+    {:membrane_rtp_h264_plugin, "~> 0.19.2"}
   ]
 end
 ```

--- a/lib/rtp_h264/payloader.ex
+++ b/lib/rtp_h264/payloader.ex
@@ -121,7 +121,7 @@ defmodule Membrane.RTP.H264.Payloader do
         stap_acc
         | payloads: [buffer.payload | stap_acc.payloads],
           byte_size: size,
-          metadata: stap_acc.metadata || buffer.metadata,
+          metadata: buffer.metadata,
           pts: buffer.pts,
           dts: buffer.dts,
           nri: max(stap_acc.nri, nri),

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.RTP.H264.MixProject do
   use Mix.Project
 
-  @version "0.19.1"
+  @version "0.19.2"
   @github_url "https://github.com/membraneframework/membrane_rtp_h264_plugin"
 
   def project do


### PR DESCRIPTION
This PR:
* fixes a bug of not setting the `marker bit` of STAP-A RTP packets if the final NALu of a STAP packet is the last NALu of an access unit

The bugfix updates the metadata in the `stap_acc` each time a new buffer is processed, so that to make sure that when the `stap_acc` gets flushed, its the metadata of the final buffer (that might have `end_access_unit: true` set) that is used in the `set_marker` function.
